### PR TITLE
fix failing GlobalAutoscalingConfigurationSetFixture tests

### DIFF
--- a/DynamoDbAutoscaler.Test/Configuration/GlobalAutoscalingConfigurationSetFixture.cs
+++ b/DynamoDbAutoscaler.Test/Configuration/GlobalAutoscalingConfigurationSetFixture.cs
@@ -1,26 +1,40 @@
-﻿using DynamoDbAutoscaler.Configuration;
-using NUnit.Framework;
+﻿using System.IO;
 using System.Threading.Tasks;
+
+using DynamoDbAutoscaler.Configuration;
+using NUnit.Framework;
 
 namespace DynamoDbAutoscaler.Test.Configuration
 {
     [TestFixture]
     public class GlobalAutoscalingConfigurationSetFixture
-    {        
+    {
+        private static string GetLocalFilePath()
+        {
+            var basePath = TestContext.CurrentContext.TestDirectory;
+            var localFilePath = Path.Combine(basePath, "autoscaling.json");
+
+            return localFilePath;
+        }
 
         [Test]
         public async Task LoadFromFile_ShouldLoadAndSerializeConfiguration()
         {
-            var configuration = await GlobalAutoscalingConfigurationSet.LoadFromFileAsync(".\autoscaling.json");
+            var localFilePath = GetLocalFilePath();
+            var configuration = await GlobalAutoscalingConfigurationSet.LoadFromFileAsync(localFilePath);
 
             Assert.That(configuration.CheckInterval, Is.EqualTo(60));
             Assert.That(configuration.DemoMode, Is.EqualTo(true));
+            
+            // reads
             Assert.That(configuration.Reads.EnableAutoscaling, Is.EqualTo(true));
             Assert.That(configuration.Reads.UpperThreshold, Is.EqualTo(50));
             Assert.That(configuration.Reads.LowerThreshold, Is.EqualTo(25));
             Assert.That(configuration.Reads.ThrottleThreshold, Is.EqualTo(100));
             Assert.That(configuration.Reads.IncreaseWithPercent, Is.EqualTo(65));
             Assert.That(configuration.Reads.DecreaseWithPercent, Is.EqualTo(45));
+
+            // writes
             Assert.That(configuration.Writes.EnableAutoscaling, Is.EqualTo(true));
             Assert.That(configuration.Writes.UpperThreshold, Is.EqualTo(50));
             Assert.That(configuration.Writes.LowerThreshold, Is.EqualTo(25));
@@ -32,14 +46,19 @@ namespace DynamoDbAutoscaler.Test.Configuration
         [Test]
         public async Task LoadFromFile_ShouldLoadAndSerializeAllChildrenConfigurationAndSetGlobalWhenEmpty()
         {
-            var configuration = await GlobalAutoscalingConfigurationSet.LoadFromFileAsync();
+            var localFilePath = GetLocalFilePath();
+            var configuration = await GlobalAutoscalingConfigurationSet.LoadFromFileAsync(localFilePath);
 
             foreach (var child in configuration.TableConfigurations)
             {
                 Assert.That(child.DemoMode, Is.EqualTo(true));
+
+                // reads
                 Assert.That(child.Reads.EnableAutoscaling, Is.EqualTo(true));
                 Assert.That(child.Reads.MaxProvisioned, Is.GreaterThan(0));
                 Assert.That(child.Reads.MinProvisioned, Is.GreaterThan(0));
+
+                // writes
                 Assert.That(child.Writes.EnableAutoscaling, Is.EqualTo(true));
                 Assert.That(child.Writes.MaxProvisioned, Is.GreaterThan(0));
                 Assert.That(child.Writes.MinProvisioned, Is.GreaterThan(0));
@@ -48,9 +67,13 @@ namespace DynamoDbAutoscaler.Test.Configuration
             foreach (var child in configuration.GlobalSecondaryIndexConfigurations)
             {
                 Assert.That(child.DemoMode, Is.EqualTo(true));
+
+                // reads
                 Assert.That(child.Reads.EnableAutoscaling, Is.EqualTo(true));
                 Assert.That(child.Reads.MaxProvisioned, Is.GreaterThan(0));
                 Assert.That(child.Reads.MinProvisioned, Is.GreaterThan(0));
+
+                // writes
                 Assert.That(child.Writes.EnableAutoscaling, Is.EqualTo(true));
                 Assert.That(child.Writes.MaxProvisioned, Is.GreaterThan(0));
                 Assert.That(child.Writes.MinProvisioned, Is.GreaterThan(0));

--- a/DynamoDbAutoscaler.Test/DynamoDbAutoscaler.Test.csproj
+++ b/DynamoDbAutoscaler.Test/DynamoDbAutoscaler.Test.csproj
@@ -75,8 +75,7 @@
     <Compile Include="UnitTestLogger.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\autoscaling.json">
-      <Link>autoscaling.json</Link>
+    <None Include="autoscaling.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="packages.config" />

--- a/DynamoDbAutoscaler.Test/autoscaling.json
+++ b/DynamoDbAutoscaler.Test/autoscaling.json
@@ -1,0 +1,67 @@
+﻿{
+    "CheckInterval": 60,
+    "DemoMode": true,
+    "Reads": {
+        "EnableAutoscaling": true,
+        "UpperThreshold": 50,
+        "LowerThreshold": 25,
+        "ThrottleThreshold": 100,
+        "IncreaseWithPercent": 65,
+        "DecreaseWithPercent": 45
+    },
+    "Writes": {
+        "EnableAutoscaling": true,
+        "UpperThreshold": 50,
+        "LowerThreshold": 25,
+        "ThrottleThreshold": 200,
+        "IncreaseWithPercent": 20,
+        "DecreaseWithPercent": 45
+    },
+    "TableConfigurations": [
+        {
+            "DemoMode": true,
+            "TableName": "table1",
+            "Reads": {
+                "EnableAutoscaling": true,
+                "MinProvisioned": 1,
+                "MaxProvisioned": 100
+            },
+            "Writes": {
+                "EnableAutoscaling": true,
+                "MinProvisioned": 1,
+                "MaxProvisioned": 1000
+            }
+        },
+        {
+            "DemoMode": true,
+            "TableName": "table2",
+            "Reads": {
+                "EnableAutoscaling": true,
+                "MinProvisioned": 1,
+                "MaxProvisioned": 10
+            },
+            "Writes": {
+                "EnableAutoscaling": true,
+                "MinProvisioned": 1,
+                "MaxProvisioned": 150
+            }
+        }
+    ],
+    "GlobalSecondaryIndexConfigurations": [
+        {
+            "DemoMode": true,
+            "TableName": "table1",
+            "IndexName": "index1",
+            "Reads": {
+                "EnableAutoscaling": true,
+                "MinProvisioned": 1,
+                "MaxProvisioned": 10
+            },
+            "Writes": {
+                "EnableAutoscaling": true,
+                "MinProvisioned": 1,
+                "MaxProvisioned": 10
+            }
+        }
+    ]
+}

--- a/autoscaling.json
+++ b/autoscaling.json
@@ -1,40 +1,67 @@
 ﻿{
-    "CheckInterval": 120,
+    "CheckInterval": 60,
     "DemoMode": true,
     "Reads": {
         "EnableAutoscaling": true,
         "UpperThreshold": 50,
         "LowerThreshold": 25,
-        "ThrottleThreshold": 50,
-        "IncreaseWithPercent": 50,
-        "DecreaseWithPercent": 45,
+        "ThrottleThreshold": 100,
+        "IncreaseWithPercent": 65,
+        "DecreaseWithPercent": 45
     },
     "Writes": {
         "EnableAutoscaling": true,
         "UpperThreshold": 50,
         "LowerThreshold": 25,
-        "ThrottleThreshold": 50,
-        "IncreaseWithPercent": 50,
-        "DecreaseWithPercent": 45,
+        "ThrottleThreshold": 200,
+        "IncreaseWithPercent": 20,
+        "DecreaseWithPercent": 45
     },
     "TableConfigurations": [
         {
+            "DemoMode": true,
             "TableName": "table1",
-            "Reads": { "MinProvisioned": 1, "MaxProvisioned": 100 },
-            "Writes": { "MinProvisioned": 1, "MaxProvisioned": 1000 }
+            "Reads": {
+                "EnableAutoscaling": true,
+                "MinProvisioned": 1,
+                "MaxProvisioned": 100
+            },
+            "Writes": {
+                "EnableAutoscaling": true,
+                "MinProvisioned": 1,
+                "MaxProvisioned": 1000
+            }
         },
         {
+            "DemoMode": true,
             "TableName": "table2",
-            "Reads": { "MinProvisioned": 1, "MaxProvisioned": 10 },
-            "Writes": { "MinProvisioned": 1, "MaxProvisioned": 150 }
+            "Reads": {
+                "EnableAutoscaling": true,
+                "MinProvisioned": 1,
+                "MaxProvisioned": 10
+            },
+            "Writes": {
+                "EnableAutoscaling": true,
+                "MinProvisioned": 1,
+                "MaxProvisioned": 150
+            }
         }
     ],
     "GlobalSecondaryIndexConfigurations": [
         {
+            "DemoMode": true,
             "TableName": "table1",
             "IndexName": "index1",
-            "Reads": { "MinProvisioned": 1, "MaxProvisioned": 10 },
-            "Writes": { "MinProvisioned": 1, "MaxProvisioned": 10 }
+            "Reads": {
+                "EnableAutoscaling": true,
+                "MinProvisioned": 1,
+                "MaxProvisioned": 10
+            },
+            "Writes": {
+                "EnableAutoscaling": true,
+                "MinProvisioned": 1,
+                "MaxProvisioned": 10
+            }
         }
     ]
 }

--- a/autoscaling.json
+++ b/autoscaling.json
@@ -1,67 +1,40 @@
 ﻿{
-    "CheckInterval": 60,
+    "CheckInterval": 120,
     "DemoMode": true,
     "Reads": {
         "EnableAutoscaling": true,
         "UpperThreshold": 50,
         "LowerThreshold": 25,
-        "ThrottleThreshold": 100,
-        "IncreaseWithPercent": 65,
-        "DecreaseWithPercent": 45
+        "ThrottleThreshold": 50,
+        "IncreaseWithPercent": 50,
+        "DecreaseWithPercent": 45,
     },
     "Writes": {
         "EnableAutoscaling": true,
         "UpperThreshold": 50,
         "LowerThreshold": 25,
-        "ThrottleThreshold": 200,
-        "IncreaseWithPercent": 20,
-        "DecreaseWithPercent": 45
+        "ThrottleThreshold": 50,
+        "IncreaseWithPercent": 50,
+        "DecreaseWithPercent": 45,
     },
     "TableConfigurations": [
         {
-            "DemoMode": true,
             "TableName": "table1",
-            "Reads": {
-                "EnableAutoscaling": true,
-                "MinProvisioned": 1,
-                "MaxProvisioned": 100
-            },
-            "Writes": {
-                "EnableAutoscaling": true,
-                "MinProvisioned": 1,
-                "MaxProvisioned": 1000
-            }
+            "Reads": { "MinProvisioned": 1, "MaxProvisioned": 100 },
+            "Writes": { "MinProvisioned": 1, "MaxProvisioned": 1000 }
         },
         {
-            "DemoMode": true,
             "TableName": "table2",
-            "Reads": {
-                "EnableAutoscaling": true,
-                "MinProvisioned": 1,
-                "MaxProvisioned": 10
-            },
-            "Writes": {
-                "EnableAutoscaling": true,
-                "MinProvisioned": 1,
-                "MaxProvisioned": 150
-            }
+            "Reads": { "MinProvisioned": 1, "MaxProvisioned": 10 },
+            "Writes": { "MinProvisioned": 1, "MaxProvisioned": 150 }
         }
     ],
     "GlobalSecondaryIndexConfigurations": [
         {
-            "DemoMode": true,
             "TableName": "table1",
             "IndexName": "index1",
-            "Reads": {
-                "EnableAutoscaling": true,
-                "MinProvisioned": 1,
-                "MaxProvisioned": 10
-            },
-            "Writes": {
-                "EnableAutoscaling": true,
-                "MinProvisioned": 1,
-                "MaxProvisioned": 10
-            }
+            "Reads": { "MinProvisioned": 1, "MaxProvisioned": 10 },
+            "Writes": { "MinProvisioned": 1, "MaxProvisioned": 10 }
         }
     ]
 }


### PR DESCRIPTION
The GlobalAutoscalingConfigurationSetFixture tests were failing for me, so I fixed them by getting the full path to the autoscaling.json file and updating the values in autoscaling.json to match the assertions. Created a separate autoscaling.json file for use exclusively by the tests so the existing example file could remain unchanged.